### PR TITLE
:bug: Fix at::server_write() memory bug

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,4 +5,3 @@ If:
 Else:
   CompileFlags:
     CompilationDatabase: .
-

--- a/.github/workflows/3.0.1.yml
+++ b/.github/workflows/3.0.1.yml
@@ -1,0 +1,11 @@
+name: 🚀 Deploy 3.0.1
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: libhal/ci/.github/workflows/deploy_all.yml@5.x.y
+    with:
+      version: 3.0.1
+    secrets: inherit

--- a/demos/applications/at.cpp
+++ b/demos/applications/at.cpp
@@ -18,7 +18,6 @@
 #include <libhal/timeout.hpp>
 
 #include "../hardware_map.hpp"
-#include "helper.hpp"
 
 void application(hardware_map_t& p_map)
 {
@@ -29,8 +28,8 @@ void application(hardware_map_t& p_map)
   auto& serial = *p_map.serial;
   auto& console = *p_map.console;
 
-  std::string_view ssid = "ssid";
-  std::string_view password = "password";
+  constexpr std::string_view ssid = "<insert ssid here>";
+  constexpr std::string_view password = "<insert password here>";
 
   hal::print(console, "ESP8266 WiFi Client Application Starting...\n");
 

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -22,4 +22,4 @@ class demos(ConanFile):
     def requirements(self):
         bootstrap = self.python_requires["libhal-bootstrap"]
         bootstrap.module.add_demo_requirements(self)
-        self.requires("libhal-esp8266/[^3.0.0 || latest]")
+        self.requires("libhal-esp8266/[^3.0.1 || latest]")

--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -30,3 +30,11 @@ int main()
 
   return 0;
 }
+
+extern "C"
+{
+  // This gets rid of an issue with libhal-exceptions in Debug mode.
+  void __assert_func()
+  {
+  }
+}

--- a/src/at.cpp
+++ b/src/at.cpp
@@ -312,7 +312,7 @@ std::span<const hal::byte> at::server_write(std::span<const hal::byte> p_data,
   using namespace std::literals;
 
   // Trim data to the maximum packet length.
-  p_data = p_data.subspan(0, maximum_transmit_packet_size);
+  p_data = p_data.first(std::min(p_data.size(), maximum_transmit_packet_size));
 
   hal::write(*m_serial, "AT+CIPSEND=", p_timeout);
   hal::write(*m_serial, uint_to_string(p_data.size()).str(), p_timeout);


### PR DESCRIPTION
server_write was supposed to clamp the input to the maximum send limit, but instead, extended the span to the maximum send limit, spilling out contents of rodata to the server which is bad on so many levels.

Updated demo to use a streamed based class for parsing an HTTP get request.